### PR TITLE
Fix missing cases in get_libc_info, get_libgcc_info

### DIFF
--- a/lib/packages.py
+++ b/lib/packages.py
@@ -365,7 +365,7 @@ def get_package_info(vgls):
 
 def get_libc_info(vgls):
     if not "config-libc" in vgls["config"]:
-        return
+        return None, None
     libc_package = vgls["config"]["config-libc"]
     make_path = os.path.join(vgls["bdir"], "toolchain", libc_package, "common.mk")
     pkg_name, pkg_version, pkg_license, package_supplier = libc_package, UNSET, UNKNOWN, PACKAGE_SUPPLIER
@@ -409,7 +409,7 @@ def get_libc_info(vgls):
 
 def get_libgcc_info(vgls):
     if not "config-package-libgcc" in vgls["config"]:
-        return None, None
+        return None
 
     make_path = os.path.join(vgls["bdir"], "toolchain", "gcc", "common.mk")
     pkg_name, pkg_license, package_supplier = "gcc", UNKNOWN, PACKAGE_SUPPLIER


### PR DESCRIPTION
When `libc` or `libgcc` are not selected in the `.config` file the tool currently fails. 

Missing `libc` error: 
```
Traceback (most recent call last):
  File "/Users/ranlytics/src/vigiles-openwrt/vigiles-openwrt.py", line 257, in <module>
    __main__()
  File "/Users/ranlytics/src/vigiles-openwrt/vigiles-openwrt.py", line 251, in __main__
    collect_metadata(vgls)
  File "/Users/ranlytics/src/vigiles-openwrt/vigiles-openwrt.py", line 212, in collect_metadata
    vgls["packages"] = packages.get_package_info(vgls)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ranlytics/src/vigiles-openwrt/lib/packages.py", line 357, in get_package_info
    pkg_dict = get_toolchain_info(vgls, known_packages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ranlytics/src/vigiles-openwrt/lib/packages.py", line 457, in get_toolchain_info
    libc_package, libc_info = get_libc_info(vgls)
    ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot unpack non-iterable NoneType object

```

Missing `libgcc` error:
```
Traceback (most recent call last):
  File "/Users/ranlytics/src/vigiles-openwrt/vigiles-openwrt.py", line 257, in <module>
    __main__()
  File "/Users/ranlytics/src/vigiles-openwrt/vigiles-openwrt.py", line 251, in __main__
    collect_metadata(vgls)
  File "/Users/ranlytics/src/vigiles-openwrt/vigiles-openwrt.py", line 212, in collect_metadata
    vgls["packages"] = packages.get_package_info(vgls)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ranlytics/src/vigiles-openwrt/lib/packages.py", line 357, in get_package_info
    pkg_dict = get_toolchain_info(vgls, known_packages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ranlytics/src/vigiles-openwrt/lib/packages.py", line 465, in get_toolchain_info
    dbg("%s version: %s" % (libgcc_info["name"], libgcc_info["version"]))
                            ~~~~~~~~~~~^^^^^^^^
TypeError: tuple indices must be integers or slices, not str
```

This PR corrects the short circuit cases in `get_libc_info` and `get_libgcc_info` to match the number of expected return values from these methods as per their usage in `get_toolchain_info`. I've tested this against a `.config` file missing both `libc` and `libgcc` to validate that both cases failing is well supported. 